### PR TITLE
Refactor CSS organization

### DIFF
--- a/src/components/BlogPost.astro
+++ b/src/components/BlogPost.astro
@@ -1,4 +1,5 @@
 ---
+import '../styles/blogpost.css';
 const { title, url, date, description, tags = [] } = Astro.props;
 ---
 <div transition:animate="slide" class="project-card-sm" data-tags={tags.join(',')}>
@@ -20,27 +21,3 @@ const { title, url, date, description, tags = [] } = Astro.props;
   </div>
   </a>
 </div>
-
-<style>
-  .tag-list {
-    margin-top: 0.5rem;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.25rem;
-  }
-
-  .tag,
-  .tag-filter {
-    border: 1px solid var(--highlight);
-    border-radius: 9999px;
-    padding: 0.1rem 0.5rem;
-    font-size: 0.75rem;
-    color: var(--highlight);
-  }
-
-  .light .tag,
-  .light .tag-filter {
-    border-color: var(--purplight);
-    color: var(--purplight);
-  }
-</style>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -10,12 +10,6 @@ const today = new Date();
         <a href="/about">
             <svg class="mailbox-icon" fill="#ffffff" height="24px" width="24px" id="Capa_1" viewBox="0 0 24 24">
                 <title>contact</title>
-                <style>
-                    svg.mailbox-icon path{fill: #72718a;}
-                    .light svg.mailbox-icon path{fill: #1c2127;} 
-                    svg.mailbox-icon:hover path{fill: #ffabff}
-                    .light svg.mailbox-icon:hover path{fill: #9636bf}
-                </style>
                 <g>
                     <path d="M19 0C17.3431 0 16 1.34315 16 3H7C3.68629 3 1 5.68629 1 9V18C1 19.6569 2.34315 21 4 21H12H20C21.6569 21 23 19.6569 23 18V9C23 7.12635 22.1412 5.45329 20.7957 4.35299C21.5283 3.78599 22 2.89808 22 1.9C22 0.850659 21.1493 0 20.1 0H19ZM16 5V10C16 10.5523 16.4477 11 17 11C17.5523 11 18 10.5523 18 10V5.12602C19.7252 5.57006 21 7.13616 21 9V18C21 18.5523 20.5523 19 20 19H13V9C13 7.46329 12.4223 6.06151 11.4722 5H16ZM18.9 3H18C18 2.44772 18.4477 2 19 2H19.9955C19.945 2.56065 19.4738 3 18.9 3ZM3 9C3 6.79086 4.79086 5 7 5C9.20914 5 11 6.79086 11 9V19H4C3.44772 19 3 18.5523 3 18V9ZM5 9C4.44772 9 4 9.44772 4 10C4 10.5523 4.44772 11 5 11H9C9.55228 11 10 10.5523 10 10C10 9.44772 9.55228 9 9 9H5Z"/>
                 </g>
@@ -24,12 +18,6 @@ const today = new Date();
         <a href="https://www.linkedin.com/in/aryanaryal" target="_blank">
             <svg class="linkedin-logo" width="24px" height="24px" viewBox="0 0 24 24">
                 <title>linked-in</title>
-                <style>
-                    svg.linkedin-logo path{fill: #72718a}
-                    .light svg.linkedin-logo path{fill: #1c2127;}
-                    svg.linkedin-logo:hover path{fill: #ffabff;}
-                    .light svg.linkedin-logo:hover path{fill: #9636bf;}
-                </style>
                 <path
                     d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z"/>
             </svg>
@@ -37,42 +25,11 @@ const today = new Date();
         <a href="https://github.com/pyarya" target="_blank">
             <svg class="github-logo" viewBox="0 0 16 16" aria-hidden="true" width="24" height="24">
                 <title>github</title>
-                <style>
-                    svg.github-logo{fill:#72718a;}
-                    .light svg.github-logo{fill:#1c2127;}
-                    svg.github-logo:hover{fill:#ffabff;}
-                    .light svg.github-logo:hover{fill:#9636bf;}
-                </style>
                 <path
                     d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
             </svg>
             
         </a>
-        <!-- <a href="https://anilist.co/user/aryarya" target="_blank">
-            <svg class="anilist-logo" width="24px" height="24px" viewBox="0 0 32 32">
-                <title>anilist</title>
-                <style>
-                    svg.anilist-logo rect {fill:#72718a;}
-                    .light svg.anilist-logo rect {fill:#1c2127;}
-                    svg.anilist-logo:hover rect {fill:#ffabff;}
-                    .light svg.anilist-logo:hover rect {fill:#9636bf;}
-                    svg.anilist-logo path {stroke:none; fill-rule:nonzero; fill-opacity:1;}
-                    svg.anilist-logo path.A {fill:#1c2127;}
-                    .light svg.anilist-logo path.A {fill:#fff3e1}
-                    svg.anilist-logo path.L {fill:#ccc;}
-                    
-                </style>
-                <g id="surface1">
-                    <rect rx="8" x="0" y="0" width="32" height="32" data-astro-cid-sz7xmlte=""></rect>
-                    <path
-                        class="L"
-                        d="M 20.121094 20.203125 L 20.121094 8.539062 C 20.121094 7.867188 19.753906 7.5 19.085938 7.5 L 16.808594 7.5 C 16.140625 7.5 15.773438 7.867188 15.773438 8.539062 L 15.773438 14.078125 C 15.773438 14.234375 17.273438 14.957031 17.3125 15.113281 C 18.453125 19.585938 17.558594 23.167969 16.476562 23.335938 C 18.25 23.425781 18.441406 24.277344 17.125 23.695312 C 17.324219 21.308594 18.113281 21.3125 20.375 23.605469 C 20.394531 23.628906 20.839844 24.5625 20.867188 24.5625 L 26.214844 24.5625 C 26.882812 24.5625 27.25 24.195312 27.25 23.523438 L 27.25 21.242188 C 27.25 20.574219 26.882812 20.203125 26.214844 20.203125 Z M 20.121094 20.203125 "/>
-                    <path
-                        class="A"
-                        d="M 10.667969 7.5 L 4.6875 24.5625 L 9.332031 24.5625 L 10.34375 21.609375 L 15.40625 21.609375 L 16.394531 24.5625 L 21.019531 24.5625 L 15.0625 7.5 Z M 11.402344 17.828125 L 12.851562 13.101562 L 14.441406 17.828125 Z M 11.402344 17.828125 "/>
-                </g>
-            </svg>
-        </a>         -->
         </p>
         <center style="color: #72718a; margin:1.25%; font-size: small;">©{today.getFullYear()} Aryan Aryal. Licensed under AGPL.</center>
     <ThemeIcon />

--- a/src/components/Hamburger.astro
+++ b/src/components/Hamburger.astro
@@ -18,12 +18,6 @@
         <a href="/about">
             <svg class="mailbox-icon" fill="#ffffff" height="26px" width="26px" id="Capa_1" viewBox="0 0 24 24">
                 <title>contact</title>
-                <style>
-                    svg.mailbox-icon path{fill: #72718a;}
-                    .light svg.mailbox-icon path{fill: #5a554d;}
-                    svg.mailbox-icon:hover path{fill: #ffabff}
-                    .light svg.mailbox-icon:hover path{fill: #9636bf}
-                </style>
                 <g>
                     <path d="M19 0C17.3431 0 16 1.34315 16 3H7C3.68629 3 1 5.68629 1 9V18C1 19.6569 2.34315 21 4 21H12H20C21.6569 21 23 19.6569 23 18V9C23 7.12635 22.1412 5.45329 20.7957 4.35299C21.5283 3.78599 22 2.89808 22 1.9C22 0.850659 21.1493 0 20.1 0H19ZM16 5V10C16 10.5523 16.4477 11 17 11C17.5523 11 18 10.5523 18 10V5.12602C19.7252 5.57006 21 7.13616 21 9V18C21 18.5523 20.5523 19 20 19H13V9C13 7.46329 12.4223 6.06151 11.4722 5H16ZM18.9 3H18C18 2.44772 18.4477 2 19 2H19.9955C19.945 2.56065 19.4738 3 18.9 3ZM3 9C3 6.79086 4.79086 5 7 5C9.20914 5 11 6.79086 11 9V19H4C3.44772 19 3 18.5523 3 18V9ZM5 9C4.44772 9 4 9.44772 4 10C4 10.5523 4.44772 11 5 11H9C9.55228 11 10 10.5523 10 10C10 9.44772 9.55228 9 9 9H5Z"/>
                 </g>
@@ -32,12 +26,6 @@
         <a href="https://www.linkedin.com/in/aryanaryal" target="_blank">
             <svg class="linkedin-logo" width="24px" height="24px" viewBox="0 0 24 24">
                 <title>linked-in</title>
-                <style>
-                    svg.linkedin-logo path{fill: #72718a}
-                    .light svg.linkedin-logo path{fill: #5a554d;}
-                    svg.linkedin-logo:hover path{fill: #ffabff;}
-                    .light svg.linkedin-logo:hover path{fill: #9636bf;}
-                </style>
                 <path
                     d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z"/>
             </svg>
@@ -45,41 +33,11 @@
         <a href="https://github.com/pyarya" target="_blank">
             <svg class="github-logo" viewBox="0 0 16 16" aria-hidden="true" width="24" height="24">
                 <title>github</title>
-                <style>
-                    svg.github-logo{fill:#72718a;}
-                    .light svg.github-logo{fill:#5a554d;}
-                    svg.github-logo:hover{fill:#ffabff;}
-                    .light svg.github-logo:hover{fill:#9636bf;}
-                </style>
                 <path
                     d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
             </svg>
             
         </a>
-        <!-- <a href="https://anilist.co/user/aryarya" target="_blank">
-            <svg class="anilist-logo" width="24px" height="24px" viewBox="0 0 32 32">
-                <title>anilist</title>
-                <style>
-                    svg.anilist-logo rect {fill:#72718a;}
-                    .light svg.anilist-logo rect {fill:#5a554d;}
-                    svg.anilist-logo:hover rect {fill:#ffabff;}
-                    .light svg.anilist-logo:hover rect {fill:#9636bf;}
-                    svg.anilist-logo path {stroke:none; fill-rule:nonzero; fill-opacity:1;}
-                    svg.anilist-logo path.A {fill:#1c2127;}
-                    .light svg.anilist-logo path.A {fill:#fff3e1}
-                    svg.anilist-logo path.L {fill:#ccc;}
-                </style>
-                <g id="surface1">
-                    <rect rx="8" x="0" y="0" width="32" height="32" data-astro-cid-sz7xmlte=""></rect>
-                    <path
-                        class="L"
-                        d="M 20.121094 20.203125 L 20.121094 8.539062 C 20.121094 7.867188 19.753906 7.5 19.085938 7.5 L 16.808594 7.5 C 16.140625 7.5 15.773438 7.867188 15.773438 8.539062 L 15.773438 14.078125 C 15.773438 14.234375 17.273438 14.957031 17.3125 15.113281 C 18.453125 19.585938 17.558594 23.167969 16.476562 23.335938 C 18.25 23.425781 18.441406 24.277344 17.125 23.695312 C 17.324219 21.308594 18.113281 21.3125 20.375 23.605469 C 20.394531 23.628906 20.839844 24.5625 20.867188 24.5625 L 26.214844 24.5625 C 26.882812 24.5625 27.25 24.195312 27.25 23.523438 L 27.25 21.242188 C 27.25 20.574219 26.882812 20.203125 26.214844 20.203125 Z M 20.121094 20.203125 "/>
-                    <path
-                        class="A"
-                        d="M 10.667969 7.5 L 4.6875 24.5625 L 9.332031 24.5625 L 10.34375 21.609375 L 15.40625 21.609375 L 16.394531 24.5625 L 21.019531 24.5625 L 15.0625 7.5 Z M 11.402344 17.828125 L 12.851562 13.101562 L 14.441406 17.828125 Z M 11.402344 17.828125 "/>
-                </g>
-            </svg>
-        </a>         -->
       </li>
 
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 2000" style="height: 120%;">
@@ -89,12 +47,4 @@
       
     </ul>
   </div>
-  <style>
-    .icons {
-      display: flex;
-      justify-content: space-around;
-      align-items: left;
-      margin-top: auto;
-    }
-  </style>
 </div>

--- a/src/components/ThemeIcon.astro
+++ b/src/components/ThemeIcon.astro
@@ -1,25 +1,10 @@
 ---
+import '../styles/theme-icon.css';
 ---
 <button id="themeToggle">
     <p class="kawaii">ദ്ദി ˉ͈̀꒳ˉ͈́ )✧</p>
   </button>
 
-<style>
-    #themeToggle {
-    border: none;
-    background: none;
-    /* padding: 0.5rem 0 0.5rem 0; */
-  }
-  
-  .kawaii {
-    transition: transform 1s ease;
-  }
-
-  #themeToggle:hover .kawaii {
-    cursor: pointer;
-    transform: rotate(360deg);
-  }
-</style>
 
 <script is:inline>
   document.addEventListener('astro:page-load', () => {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,6 +2,7 @@
 import { ClientRouter } from 'astro:transitions';
 const { PageTitle } = Astro.props;
 import '../styles/global.css';
+import '../styles/icons.css';
 import '@fontsource-variable/source-code-pro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';

--- a/src/layouts/MDPostLayout.astro
+++ b/src/layouts/MDPostLayout.astro
@@ -2,6 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 const { frontmatter } = Astro.props;
 import '../styles/markdown.css';
+import '../styles/mdpost.css';
 ---
 
 <BaseLayout PageTitle={frontmatter.title}>
@@ -10,16 +11,7 @@ import '../styles/markdown.css';
     <p transition:animate="slide" ><em>{frontmatter.description}</em></p>
     <div class="prose">
         <slot />
-        <span >
-            <style>
-                .light {
-                    color: #72718a;
-                }
-                span {
-                    color: #72718a;
-                }
-            </style>
-        [user@arysite ~]$</span>
+        <span class="post-prompt">[user@arysite ~]$</span>
         <a href="javascript:history.back()">cd ..</a>
         <hr>
     </div>

--- a/src/layouts/homelayout.astro
+++ b/src/layouts/homelayout.astro
@@ -2,6 +2,7 @@
 import { ClientRouter } from 'astro:transitions';
 const { PageTitle } = Astro.props;
 import '../styles/global.css';
+import '../styles/icons.css';
 import '@fontsource-variable/source-code-pro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import { fade } from 'astro:transitions';
 import HomeLayout from '../layouts/homelayout.astro';
+import '../styles/home.css';
 
 const PageTitle = 'home';
 ---
@@ -26,16 +27,3 @@ const PageTitle = 'home';
         </div>
     </section>
 </HomeLayout>
-
-<style>
-	.intro {
-                display: flex;
-                flex-direction: column;
-                align-items: center;
-                text-align: left;
-        }
-
-	.intro .text {
-			width: auto;
-	}
-</style>

--- a/src/pages/posts.astro
+++ b/src/pages/posts.astro
@@ -2,6 +2,7 @@
 import { getCollection } from "astro:content";
 import BaseLayout from '../layouts/BaseLayout.astro';
 import BlogPost from '../components/BlogPost.astro';
+import '../styles/posts.css';
 
 const posts = await getCollection("posts");
 const visiblePosts = posts.filter((post) => !post.data.draft);
@@ -31,70 +32,3 @@ const PageTitle = "📢Posts";
         </div>
         <script src="../scripts/tagfilter.js"></script>
 </BaseLayout>
-
-<style>
-    :root {
-        --bg-colour-light: #f5f5f5;
-        --bg-colour-light-shade:#ececec;
-        --bg-colour: #1c2127;
-        --bg-colour-shade: #171a20;
-        --highlight: #ffabff;
-        --purplight: #9636bf;
-    }
-
-    .projects-container {
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: space-between;
-        gap: 0.5rem;
-    }
-
-    .filter-container {
-        display: flex;
-        justify-content: center;
-        flex-wrap: wrap;
-        gap: 0.5rem;
-        margin-bottom: 1rem;
-    }
-
-    .tag-filter {
-        border: 1.5px solid var(--highlight);
-        border-radius: 9999px;
-        padding: 0.25rem 0.5rem;
-        background: none;
-        color: var(--highlight);
-        font-size: .85rem;
-        font-weight: 500;
-        cursor: pointer;
-        transition: 
-            background-color 0.3s ease,
-            transform 0.2s ease,
-            box-shadow 0.2s ease;
-    }
-
-    .tag-filter.active {
-        background-color: var(--highlight);
-        color: var(--bg-colour);
-    }
-
-    .light .tag-filter {
-        border-color: var(--purplight);
-        color: var(--purplight);
-    }
-
-    .light .tag-filter.active {
-        background-color: var(--purplight);
-        color: var(--purplight);
-    }
-
-    .tag-filter:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 8px 15px rgba(0, 0, 0, 0.2);
-    }
-    
-    @media (max-width: 725px){
-        .projects-container {
-            justify-content: center;
-        }
-    }
-</style>

--- a/src/styles/blogpost.css
+++ b/src/styles/blogpost.css
@@ -1,0 +1,21 @@
+.tag-list {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.tag,
+.tag-filter {
+  border: 1px solid var(--highlight);
+  border-radius: 9999px;
+  padding: 0.1rem 0.5rem;
+  font-size: 0.75rem;
+  color: var(--highlight);
+}
+
+.light .tag,
+.light .tag-filter {
+  border-color: var(--purplight);
+  color: var(--purplight);
+}

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -1,0 +1,10 @@
+.intro {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: left;
+}
+
+.intro .text {
+  width: auto;
+}

--- a/src/styles/icons.css
+++ b/src/styles/icons.css
@@ -1,0 +1,45 @@
+svg.mailbox-icon path {
+  fill: #72718a;
+}
+.light svg.mailbox-icon path {
+  fill: var(--bg-colour);
+}
+svg.mailbox-icon:hover path {
+  fill: var(--highlight);
+}
+.light svg.mailbox-icon:hover path {
+  fill: var(--purplight);
+}
+
+svg.linkedin-logo path {
+  fill: #72718a;
+}
+.light svg.linkedin-logo path {
+  fill: var(--bg-colour);
+}
+svg.linkedin-logo:hover path {
+  fill: var(--highlight);
+}
+.light svg.linkedin-logo:hover path {
+  fill: var(--purplight);
+}
+
+svg.github-logo {
+  fill: #72718a;
+}
+.light svg.github-logo {
+  fill: var(--bg-colour);
+}
+svg.github-logo:hover {
+  fill: var(--highlight);
+}
+.light svg.github-logo:hover {
+  fill: var(--purplight);
+}
+
+.icons {
+  display: flex;
+  justify-content: space-around;
+  align-items: flex-start;
+  margin-top: auto;
+}

--- a/src/styles/mdpost.css
+++ b/src/styles/mdpost.css
@@ -1,0 +1,3 @@
+.post-prompt {
+  color: #72718a;
+}

--- a/src/styles/posts.css
+++ b/src/styles/posts.css
@@ -1,0 +1,55 @@
+.projects-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.filter-container {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.tag-filter {
+  border: 1.5px solid var(--highlight);
+  border-radius: 9999px;
+  padding: 0.25rem 0.5rem;
+  background: none;
+  color: var(--highlight);
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background-color 0.3s ease,
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.tag-filter.active {
+  background-color: var(--highlight);
+  color: var(--bg-colour);
+}
+
+.light .tag-filter {
+  border-color: var(--purplight);
+  color: var(--purplight);
+}
+
+.light .tag-filter.active {
+  background-color: var(--purplight);
+  color: var(--purplight);
+}
+
+.tag-filter:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 15px rgba(0, 0, 0, 0.2);
+}
+
+@media (max-width: 725px) {
+  .projects-container {
+    justify-content: center;
+  }
+}

--- a/src/styles/theme-icon.css
+++ b/src/styles/theme-icon.css
@@ -1,0 +1,13 @@
+#themeToggle {
+  border: none;
+  background: none;
+}
+
+.kawaii {
+  transition: transform 1s ease;
+}
+
+#themeToggle:hover .kawaii {
+  cursor: pointer;
+  transform: rotate(360deg);
+}


### PR DESCRIPTION
## Summary
- split out inline styles for components and pages
- add dedicated CSS files for icons, posts, home, and blog posts
- clean up MD post layout styles
- load common icon styles via layouts

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_68657bcab5c48322a3c173cd04fbc349